### PR TITLE
CloudFormation Templates

### DIFF
--- a/cloudformation/phase-1/opentelemetry-docker.yaml
+++ b/cloudformation/phase-1/opentelemetry-docker.yaml
@@ -1,0 +1,109 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: CloudFormation template for the OpenTelemetry Docker deployment
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Networking
+        Parameters:
+          - VpcStackName
+      - Label:
+          default: Instance Configuration
+        Parameters:
+          - Tenancy
+          - KeyName
+    ParameterLabels:
+      VpcStackName:
+        default: VPC Stack Name
+      Tenancy:
+        default: Tenancy
+      KeyName:
+        default: Key Name
+
+Parameters:
+  VpcStackName:
+    Type: String
+  Tenancy:
+    Type: String
+    Description: Choose "dedicated" to create a dedicated EC2 instance
+    Default: default
+    AllowedValues: [default, dedicated]
+    # Use "default" for non-production purposes such as development, testing, demonstration, etc.
+    # Use "dedicated" for production purposes or for compliance purposes.
+  KeyName:
+    Type: AWS::EC2::KeyPair::KeyName
+    Description: Choose a pre-existing key pair to enable SSH connectivity
+
+Outputs:
+  PublicIp:
+    Description: The public IP address of the EC2 instance
+    Value: !GetAtt DockerInstance.PublicIp
+  WebStoreUrl:
+    Description: The URL for Web Store
+    Value: !Sub "http://${DockerInstance.PublicIp}:8080/"
+  GrafanaUrl:
+    Description: The URL for Grafana
+    Value: !Sub "http://${DockerInstance.PublicIp}:8080/grafana/"
+  LoadGeneratorUrl:
+    Description: The URL for Load Generator
+    Value: !Sub "http://${DockerInstance.PublicIp}:8080/loadgen/"
+  JaegerUrl:
+    Description: The URL for Jaeger
+    Value: !Sub "http://${DockerInstance.PublicIp}:8080/jaeger/ui/"
+  TracetestUrl:
+    Description: The URL for Tracetest
+    Value: !Sub "http://${DockerInstance.PublicIp}:11633/"
+  FlagdConfiguratorUrl:
+    Description: The URL for Flagd Configurator
+    Value: !Sub "http://${DockerInstance.PublicIp}:8080/feature"
+
+Resources:
+  DockerInstance:
+    # Instance may take several minutes before being able to accept requests. If you suspect the UserData script failed,
+    # SSH into the instance and review the "/var/log/cloud-init-output.log" log file.
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: ami-0166fe664262f664c # specific to us-east-1
+      InstanceType: t3.large
+      Tenancy: !Ref Tenancy
+      SubnetId:
+        Fn::ImportValue: !Sub "${VpcStackName}-InstanceSubnetId"
+      SecurityGroupIds:
+        - Fn::ImportValue: !Sub "${VpcStackName}-InstanceSecurityGroupId"
+      KeyName: !Ref KeyName
+      BlockDeviceMappings:
+        - DeviceName: /dev/xvda
+          Ebs:
+            DeleteOnTermination: true
+            Encrypted: true
+            VolumeType: gp2
+            VolumeSize: 16
+      UserData: !Base64 |
+        #!/usr/bin/env bash
+        sudo yum update -y
+
+        ## Install git
+        sudo yum install git -y
+
+        ## Install docker
+        sudo amazon-linux-extras install docker -y
+        sudo service docker start
+
+        ## Install docker compose
+        # https://docs.docker.com/compose/install/linux/#install-the-plugin-manually
+        DOCKER_CONFIG=${DOCKER_CONFIG:-/usr/local/lib/docker}
+        sudo mkdir -p $DOCKER_CONFIG/cli-plugins
+        sudo curl -SL https://github.com/docker/compose/releases/download/v2.30.3/docker-compose-linux-x86_64 -o $DOCKER_CONFIG/cli-plugins/docker-compose
+        sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+
+        ## Deploy OpenTelemetry using Docker
+        # https://opentelemetry.io/docs/demo/docker-deployment/
+        git clone https://github.com/open-telemetry/opentelemetry-demo.git
+        cd opentelemetry-demo/
+        sudo docker compose up --force-recreate --remove-orphans --detach && \
+          sudo docker compose -f docker-compose-tests.yml run traceBasedTests
+      PropagateTagsToVolumeOnCreation: true
+      Tags:
+        - Key: Name
+          Value: opentelemetry-docker-ec2

--- a/cloudformation/phase-1/opentelemetry-eks.yaml
+++ b/cloudformation/phase-1/opentelemetry-eks.yaml
@@ -1,0 +1,107 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: CloudFormation template for the OpenTelemetry EKS cluster
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Networking
+        Parameters:
+          - VpcStackName
+    ParameterLabels:
+      VpcStackName:
+        default: VPC Stack Name
+
+Parameters:
+  VpcStackName:
+    Type: String
+
+Outputs:
+  K8sClusterName:
+    Description: The name of the EKS cluster
+    Value: !Ref K8sCluster
+    Export:
+      Name: !Sub "${AWS::StackName}-K8sClusterName"
+
+Resources:
+  K8sCluster:
+    Type: AWS::EKS::Cluster
+    Properties:
+      Name: opentelemetry-eks
+      Version: 1.31
+      UpgradePolicy:
+        SupportType: STANDARD
+      RoleArn: !GetAtt K8sClusterRole.Arn
+      AccessConfig:
+        AuthenticationMode: API
+        BootstrapClusterCreatorAdminPermissions: true
+      BootstrapSelfManagedAddons: true
+      ResourcesVpcConfig:
+        EndpointPublicAccess: false
+        EndpointPrivateAccess: true
+        SubnetIds:
+          - Fn::ImportValue: !Sub "${VpcStackName}-K8sClusterSubnet0Id"
+          - Fn::ImportValue: !Sub "${VpcStackName}-K8sClusterSubnet1Id"
+        SecurityGroupIds:
+          - Fn::ImportValue: !Sub "${VpcStackName}-K8sSecurityGroupId"
+      Tags:
+        - Key: Name
+          Value: opentelemetry-eks
+  K8sClusterRole:
+    # https://docs.aws.amazon.com/eks/latest/userguide/cluster-iam-role.html
+    # https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonEKSClusterPolicy.html
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: OpenTelemetryK8sClusterRole
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: eks.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
+      Tags:
+        - Key: Name
+          Value: opentelemetry-eks-role
+  K8sWorkerNodes:
+    Type: AWS::EKS::Nodegroup
+    Properties:
+      ClusterName: !Ref K8sCluster
+      NodegroupName: opentelemetry-eks-nodes
+      NodeRole: !GetAtt K8sWorkerNodesRole.Arn
+      ScalingConfig:
+        DesiredSize: 2
+        MinSize: 0
+        MaxSize: 2
+      CapacityType: ON_DEMAND
+      InstanceTypes:
+        - t3.large
+      Subnets:
+        - Fn::ImportValue: !Sub "${VpcStackName}-K8sClusterSubnet0Id"
+        - Fn::ImportValue: !Sub "${VpcStackName}-K8sClusterSubnet1Id"
+      Tags:
+        Name: opentelemetry-eks-nodes
+  K8sWorkerNodesRole:
+    # https://docs.aws.amazon.com/eks/latest/userguide/create-node-role.html
+    # https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonEKSWorkerNodePolicy.html
+    # https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonEC2ContainerRegistryPullOnly.html
+    # https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonEKS_CNI_Policy.html
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: OpenTelemetryK8sWorkerNodesRole
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ec2.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
+        - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPullOnly
+        - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
+      Tags:
+        - Key: Name
+          Value: opentelemetry-eks-nodes-role

--- a/cloudformation/phase-1/opentelemetry-kubernetes.yaml
+++ b/cloudformation/phase-1/opentelemetry-kubernetes.yaml
@@ -1,0 +1,180 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: CloudFormation template for the OpenTelemetry Kubernetes deployment
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Networking
+        Parameters:
+          - VpcStackName
+      - Label:
+          default: Kubernetes Cluster
+        Parameters:
+          - EksStackName
+      - Label:
+          default: Instance Configuration
+        Parameters:
+          - Tenancy
+          - KeyName
+    ParameterLabels:
+      VpcStackName:
+        default: VPC Stack Name
+      EksStackName:
+        default: EKS Stack Name
+      Tenancy:
+        default: Tenancy
+      KeyName:
+        default: Key Name
+
+Parameters:
+  VpcStackName:
+    Type: String
+  EksStackName:
+    Type: String
+  Tenancy:
+    Type: String
+    Description: Choose "dedicated" to create a dedicated EC2 instance
+    Default: default
+    AllowedValues: [default, dedicated]
+    # Use "default" for non-production purposes such as development, testing, demonstration, etc.
+    # Use "dedicated" for production purposes or for compliance purposes.
+  KeyName:
+    Type: AWS::EC2::KeyPair::KeyName
+    Description: Choose a pre-existing key pair to enable SSH connectivity
+
+Outputs:
+  PublicIp:
+    Description: The public IP address of the EC2 instance
+    Value: !GetAtt K8sInstance.PublicIp
+  WebStoreUrl:
+    Description: The URL for Web Store
+    Value: !Sub "http://${K8sInstance.PublicIp}:8080/"
+  GrafanaUrl:
+    Description: The URL for Grafana
+    Value: !Sub "http://${K8sInstance.PublicIp}:8080/grafana/"
+  LoadGeneratorUrl:
+    Description: The URL for Load Generator
+    Value: !Sub "http://${K8sInstance.PublicIp}:8080/loadgen/"
+  JaegerUrl:
+    Description: The URL for Jaeger
+    Value: !Sub "http://${K8sInstance.PublicIp}:8080/jaeger/ui/"
+  FlagdConfiguratorUrl:
+    Description: The URL for Flagd Configurator
+    Value: !Sub "http://${K8sInstance.PublicIp}:8080/feature"
+
+Resources:
+  K8sInstance:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: ami-0166fe664262f664c # specific to us-east-1
+      InstanceType: t3.large
+      Tenancy: !Ref Tenancy
+      SubnetId:
+        Fn::ImportValue: !Sub "${VpcStackName}-InstanceSubnetId"
+      SecurityGroupIds:
+        - Fn::ImportValue: !Sub "${VpcStackName}-InstanceSecurityGroupId"
+      KeyName: !Ref KeyName
+      IamInstanceProfile: !Ref K8sInstanceInstanceProfile
+      BlockDeviceMappings:
+        - DeviceName: /dev/xvda
+          Ebs:
+            DeleteOnTermination: true
+            Encrypted: true
+            VolumeType: gp2
+            VolumeSize: 8
+      UserData:
+        Fn::Base64:
+          Fn::Sub:
+            - |
+              #!/usr/bin/env bash
+              sudo yum update -y
+
+              ## Update the AWS CLI
+              sudo yum remove awscli -y
+              curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+              unzip awscliv2.zip
+              sudo ./aws/install
+
+              ## Install git
+              sudo yum install git -y
+
+              ## Install kubectl
+              # https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html
+              curl -O https://s3.us-west-2.amazonaws.com/amazon-eks/1.31.2/2024-11-15/bin/linux/amd64/kubectl
+              chmod +x ./kubectl
+              mkdir -p $HOME/bin && cp ./kubectl $HOME/bin/kubectl
+              export PATH=$HOME/bin:$PATH
+              echo 'export PATH=$HOME/bin:$PATH' >> ~/.bashrc
+
+              ## Install eksctl
+              # https://eksctl.io/installation/
+              ARCH=amd64
+              PLATFORM=$(uname -s)_$ARCH
+              curl -sLO "https://github.com/eksctl-io/eksctl/releases/latest/download/eksctl_$PLATFORM.tar.gz"
+              tar -xzf eksctl_$PLATFORM.tar.gz -C /tmp && rm eksctl_$PLATFORM.tar.gz
+              sudo mv /tmp/eksctl /usr/local/bin
+
+              ## Deploy OpenTelemetry using Kubernetes
+              # https://opentelemetry.io/docs/demo/kubernetes-deployment/
+              KUBECONFIG="/home/ec2-user/.kube/config" /usr/local/bin/aws eks update-kubeconfig --region us-east-1 --name ${K8sClusterName}
+              KUBECONFIG="/home/ec2-user/.kube/config" kubectl delete --namespace otel-demo -f https://raw.githubusercontent.com/open-telemetry/opentelemetry-demo/main/kubernetes/opentelemetry-demo.yaml --ignore-not-found --wait
+              KUBECONFIG="/home/ec2-user/.kube/config" kubectl apply --namespace otel-demo -f https://raw.githubusercontent.com/open-telemetry/opentelemetry-demo/main/kubernetes/opentelemetry-demo.yaml
+              sleep 5s # not ideal, but needed to give EKS time to make the service available
+              KUBECONFIG="/home/ec2-user/.kube/config" kubectl port-forward --namespace otel-demo service/opentelemetry-demo-frontendproxy --address 0.0.0.0,:: 8080:8080
+            - K8sClusterName:
+                Fn::ImportValue: !Sub "${EksStackName}-K8sClusterName"
+      PropagateTagsToVolumeOnCreation: true
+      Tags:
+        - Key: Name
+          Value: opentelemetry-eks-ec2
+  K8sInstanceInstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      InstanceProfileName: OpenTelemetryK8sInstanceInstanceProfile
+      Roles:
+        - !Ref K8sInstanceRole
+  K8sInstanceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: OpenTelemetryK8sInstanceRole
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ec2.amazonaws.com
+            Action: sts:AssumeRole
+      Tags:
+        - Key: Name
+          Value: opentelemetry-eks-ec2-role
+  K8sInstanceRoleInlinePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: OpenTelemetryK8sInstanceRoleInlinePolicy
+      PolicyDocument:
+        # https://docs.aws.amazon.com/eks/latest/userguide/security-iam-id-based-policy-examples.html#policy-example2
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - eks:DescribeCluster
+              - eks:ListClusters
+            Resource: "*"
+      Roles:
+        - !Ref K8sInstanceRole
+  K8sInstanceAccessEntry:
+    Type: AWS::EKS::AccessEntry
+    Properties:
+      ClusterName:
+        Fn::ImportValue: !Sub "${EksStackName}-K8sClusterName"
+      PrincipalArn: !GetAtt K8sInstanceRole.Arn
+      Type: STANDARD
+      AccessPolicies:
+        - AccessScope:
+            Type: cluster
+          PolicyArn: arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy
+          # https://docs.aws.amazon.com/eks/latest/userguide/access-policy-permissions.html#access-policy-permissions-amazoneksclusteradminpolicy
+      Tags:
+        - Key: Name
+          Value: opentelemetry-eks-ec2-access-entry

--- a/cloudformation/phase-1/opentelemetry-vpc.yaml
+++ b/cloudformation/phase-1/opentelemetry-vpc.yaml
@@ -1,0 +1,237 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: CloudFormation template for the OpenTelemetry VPC
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Networking
+        Parameters:
+          - IpAddressRange
+    ParameterLabels:
+      IpAddressRange:
+        default: IP Address Range
+
+Parameters:
+  IpAddressRange:
+    Type: String
+    Description: The IP address range to use for all security group rules, expressed in CIDR notation
+
+Outputs:
+  InstanceSubnetId:
+    Description: The ID of the subnet created for the Docker & Kubernetes deployments
+    Value: !Ref InstanceSubnet
+    Export:
+      Name: !Sub "${AWS::StackName}-InstanceSubnetId"
+  InstanceSecurityGroupId:
+    Description: The ID of the security group created for the Docker & Kubernetes deployments
+    Value: !Ref InstanceSecurityGroup
+    Export:
+      Name: !Sub "${AWS::StackName}-InstanceSecurityGroupId"
+  K8sClusterSubnet0Id:
+    Description: The ID of subnet at us-east-1b created for the EKS cluster
+    Value: !Ref K8sClusterSubnet0
+    Export:
+      Name: !Sub "${AWS::StackName}-K8sClusterSubnet0Id"
+  K8sClusterSubnet1Id:
+    Description: The ID of subnet at us-east-1c created for the EKS cluster
+    Value: !Ref K8sClusterSubnet1
+    Export:
+      Name: !Sub "${AWS::StackName}-K8sClusterSubnet1Id"
+  K8sSecurityGroupId:
+    Description: The ID of the security group created for the EKS cluster
+    Value: !Ref K8sSecurityGroup
+    Export:
+      Name: !Sub "${AWS::StackName}-K8sSecurityGroupId"
+
+# USEFUL TOOL FOR DETERMINING SUBNET SIZES:
+# https://visualsubnetcalc.com/
+
+Resources:
+  ### VPC ###
+  Vpc:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.0.0.0/24
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      Tags:
+        - Key: Name
+          Value: opentelemetry-vpc
+  ### Docker & Kubernetes Deployments ###
+  InstanceSubnet:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref Vpc
+      AvailabilityZone: us-east-1a
+      CidrBlock: 10.0.0.0/26
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: Name
+          Value: opentelemetry-ec2-subnet
+  InstanceSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      VpcId: !Ref Vpc
+      GroupName: opentelemetry-ec2-sg
+      GroupDescription: Control traffic to/from the OpenTelemetry applications
+      Tags:
+        - Key: Name
+          Value: opentelemetry-ec2-sg
+  InstanceSecurityGroupIngressRule0:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref InstanceSecurityGroup
+      IpProtocol: tcp
+      CidrIp: !Ref IpAddressRange
+      FromPort: 22
+      ToPort: 22
+  InstanceSecurityGroupIngressRule1:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref InstanceSecurityGroup
+      IpProtocol: tcp
+      CidrIp: !Ref IpAddressRange
+      FromPort: 8080
+      ToPort: 8080
+  InstanceSecurityGroupIngressRule2:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref InstanceSecurityGroup
+      IpProtocol: tcp
+      CidrIp: !Ref IpAddressRange
+      FromPort: 11633
+      ToPort: 11633
+  InstanceSecurityGroupEgressRule0:
+    Type: AWS::EC2::SecurityGroupEgress
+    Properties:
+      GroupId: !Ref InstanceSecurityGroup
+      IpProtocol: -1
+      CidrIp: 0.0.0.0/0
+  ### EKS Cluster ###
+  # Amazon EKS networking requirements: https://docs.aws.amazon.com/eks/latest/userguide/network-reqs.html
+  # Amazon EKS security group requirements: https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+  K8sClusterSubnet0:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref Vpc
+      AvailabilityZone: us-east-1b
+      CidrBlock: 10.0.0.128/26
+      MapPublicIpOnLaunch: false
+      Tags:
+        - Key: Name
+          Value: opentelemetry-eks-subnet
+  K8sClusterSubnet1:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref Vpc
+      AvailabilityZone: us-east-1c
+      CidrBlock: 10.0.0.192/26
+      MapPublicIpOnLaunch: false
+      Tags:
+        - Key: Name
+          Value: opentelemetry-eks-subnet
+  K8sSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      VpcId: !Ref Vpc
+      GroupName: opentelemetry-eks-sg
+      GroupDescription: Control traffic to/from the OpenTelemetry EKS cluster control plane
+      Tags:
+        - Key: Name
+          Value: opentelemetry-eks-sg
+  K8sSecurityGroupIngressRule0:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref K8sSecurityGroup
+      IpProtocol: -1
+      SourceSecurityGroupId: !Ref K8sSecurityGroup
+  K8sSecurityGroupIngressRule1:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref K8sSecurityGroup
+      IpProtocol: tcp
+      SourceSecurityGroupId: !Ref InstanceSecurityGroup
+      FromPort: 443
+      ToPort: 443
+  K8sSecurityGroupEgressRule0:
+    Type: AWS::EC2::SecurityGroupEgress
+    Properties:
+      GroupId: !Ref K8sSecurityGroup
+      IpProtocol: -1
+      CidrIp: 0.0.0.0/0
+  ### Gateways ###
+  # Internet Gateway
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+    Properties:
+      Tags:
+        - Key: Name
+          Value: opentelemetry-igw
+  InternetGatewayAttachment:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId: !Ref Vpc
+      InternetGatewayId: !Ref InternetGateway
+  # NAT Gateway
+  # IDEA 1: Make the infrastructure more resilient by creating NAT gateways in each availability zone.
+  # IDEA 2: The NAT gateway is needed as EKS worker nodes need to interact with AWS services. This could be secured by
+  #         leveraging VPC endpoints to contain all traffic within the AWS cloud. Accomplishing this will make the NAT
+  #         gateway obsolete.
+  NatGatewayEip:
+    Type: AWS::EC2::EIP
+    Properties:
+      Domain: vpc
+  NatGateway:
+    Type: AWS::EC2::NatGateway
+    Properties:
+      AllocationId: !GetAtt NatGatewayEip.AllocationId
+      SubnetId: !Ref InstanceSubnet
+      Tags:
+        - Key: Name
+          Value: opentelemetry-nat
+  ### Route Tables ###
+  # Public Subnet Route Table
+  PublicSubnetRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref Vpc
+      Tags:
+        - Key: Name
+          Value: opentelemetry-public-rtb
+  PublicSubnetRouteTableRoute0:
+    Type: AWS::EC2::Route
+    DependsOn: InternetGatewayAttachment
+    Properties:
+      RouteTableId: !Ref PublicSubnetRouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref InternetGateway
+  InstanceSubnetRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref PublicSubnetRouteTable
+      SubnetId: !Ref InstanceSubnet
+  # Private Subnet Route Table
+  PrivateSubnetRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref Vpc
+      Tags:
+        - Key: Name
+          Value: opentelemetry-private-rtb
+  PrivateSubnetRouteTableRoute0:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref PrivateSubnetRouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId: !Ref NatGateway
+  K8sClusterSubnet0RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref PrivateSubnetRouteTable
+      SubnetId: !Ref K8sClusterSubnet0
+  K8sClusterSubnet1RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref PrivateSubnetRouteTable
+      SubnetId: !Ref K8sClusterSubnet1

--- a/cloudformation/phase-2/opentelemetry-kubernetes.yaml
+++ b/cloudformation/phase-2/opentelemetry-kubernetes.yaml
@@ -1,0 +1,189 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: CloudFormation template for the OpenTelemetry Kubernetes deployment
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Networking
+        Parameters:
+          - VpcStackName
+      - Label:
+          default: Kubernetes Cluster
+        Parameters:
+          - EksStackName
+      - Label:
+          default: Instance Configuration
+        Parameters:
+          - Tenancy
+          - KeyName
+    ParameterLabels:
+      VpcStackName:
+        default: VPC Stack Name
+      EksStackName:
+        default: EKS Stack Name
+      Tenancy:
+        default: Tenancy
+      KeyName:
+        default: Key Name
+
+Parameters:
+  VpcStackName:
+    Type: String
+  EksStackName:
+    Type: String
+  Tenancy:
+    Type: String
+    Description: Choose "dedicated" to create a dedicated EC2 instance
+    Default: default
+    AllowedValues: [default, dedicated]
+    # Use "default" for non-production purposes such as development, testing, demonstration, etc.
+    # Use "dedicated" for production purposes or for compliance purposes.
+  KeyName:
+    Type: AWS::EC2::KeyPair::KeyName
+    Description: Choose a pre-existing key pair to enable SSH connectivity
+
+Outputs:
+  PublicIp:
+    Description: The public IP address of the EC2 instance
+    Value: !GetAtt K8sInstance.PublicIp
+  WebStoreUrl:
+    Description: The URL for Web Store
+    Value: !Sub "http://${K8sInstance.PublicIp}:8080/"
+  GrafanaUrl:
+    Description: The URL for Grafana
+    Value: !Sub "http://${K8sInstance.PublicIp}:8080/grafana/"
+  LoadGeneratorUrl:
+    Description: The URL for Load Generator
+    Value: !Sub "http://${K8sInstance.PublicIp}:8080/loadgen/"
+  JaegerUrl:
+    Description: The URL for Jaeger
+    Value: !Sub "http://${K8sInstance.PublicIp}:8080/jaeger/ui/"
+  FlagdConfiguratorUrl:
+    Description: The URL for Flagd Configurator
+    Value: !Sub "http://${K8sInstance.PublicIp}:8080/feature"
+
+Resources:
+  K8sInstance:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: ami-0166fe664262f664c # specific to us-east-1
+      InstanceType: t3.large
+      Tenancy: !Ref Tenancy
+      SubnetId:
+        Fn::ImportValue: !Sub "${VpcStackName}-InstanceSubnetId"
+      SecurityGroupIds:
+        - Fn::ImportValue: !Sub "${VpcStackName}-InstanceSecurityGroupId"
+      KeyName: !Ref KeyName
+      IamInstanceProfile: !Ref K8sInstanceInstanceProfile
+      BlockDeviceMappings:
+        - DeviceName: /dev/xvda
+          Ebs:
+            DeleteOnTermination: true
+            Encrypted: true
+            VolumeType: gp2
+            VolumeSize: 8
+      UserData:
+        Fn::Base64:
+          Fn::Sub:
+            - |
+              #!/usr/bin/env bash
+              sudo yum update -y
+
+              ## Update the AWS CLI
+              sudo yum remove awscli -y
+              curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+              unzip awscliv2.zip
+              sudo ./aws/install
+
+              ## Install git
+              sudo yum install git -y
+
+              ## Install kubectl
+              # https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html
+              curl -O https://s3.us-west-2.amazonaws.com/amazon-eks/1.31.2/2024-11-15/bin/linux/amd64/kubectl
+              chmod +x ./kubectl
+              mkdir -p $HOME/bin && cp ./kubectl $HOME/bin/kubectl
+              export PATH=$HOME/bin:$PATH
+              echo 'export PATH=$HOME/bin:$PATH' >> ~/.bashrc
+
+              ## Install eksctl
+              # https://eksctl.io/installation/
+              ARCH=amd64
+              PLATFORM=$(uname -s)_$ARCH
+              curl -sLO "https://github.com/eksctl-io/eksctl/releases/latest/download/eksctl_$PLATFORM.tar.gz"
+              tar -xzf eksctl_$PLATFORM.tar.gz -C /tmp && rm eksctl_$PLATFORM.tar.gz
+              sudo mv /tmp/eksctl /usr/local/bin
+
+              ## Deploy OpenTelemetry using Kubernetes
+              # https://opentelemetry.io/docs/demo/kubernetes-deployment/
+              # KUBECONFIG="/home/ec2-user/.kube/config" /usr/local/bin/aws eks update-kubeconfig --region us-east-1 --name ${K8sClusterName}
+              # KUBECONFIG="/home/ec2-user/.kube/config" kubectl delete --namespace otel-demo -f https://raw.githubusercontent.com/open-telemetry/opentelemetry-demo/main/kubernetes/opentelemetry-demo.yaml --ignore-not-found --wait
+              # KUBECONFIG="/home/ec2-user/.kube/config" kubectl apply --namespace otel-demo -f https://raw.githubusercontent.com/open-telemetry/opentelemetry-demo/main/kubernetes/opentelemetry-demo.yaml
+              # sleep 5s # not ideal, but needed to give EKS time to make the service available
+              # KUBECONFIG="/home/ec2-user/.kube/config" kubectl port-forward --namespace otel-demo service/opentelemetry-demo-frontendproxy --address 0.0.0.0,:: 8080:8080
+
+              # COMMANDS MANUALLY RUN:
+              # git clone https://github.com/shareefm0/enpm818n-final-team-1.git
+              # cd enpm818n-final-team-1/
+              # git checkout splitting
+              # aws eks update-kubeconfig --region us-east-1 --name opentelemetry-eks
+              # kubectl apply -f split-resources/namespace/otel-demo.yaml
+              # kubectl apply --namespace otel-demo -f split-resources/ --recursive
+              # kubectl port-forward --namespace otel-demo service/opentelemetry-demo-frontendproxy --address 0.0.0.0,:: 8080:8080
+            - K8sClusterName:
+                Fn::ImportValue: !Sub "${EksStackName}-K8sClusterName"
+      PropagateTagsToVolumeOnCreation: true
+      Tags:
+        - Key: Name
+          Value: opentelemetry-eks-ec2
+  K8sInstanceInstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      InstanceProfileName: OpenTelemetryK8sInstanceInstanceProfile
+      Roles:
+        - !Ref K8sInstanceRole
+  K8sInstanceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: OpenTelemetryK8sInstanceRole
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ec2.amazonaws.com
+            Action: sts:AssumeRole
+      Tags:
+        - Key: Name
+          Value: opentelemetry-eks-ec2-role
+  K8sInstanceRoleInlinePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: OpenTelemetryK8sInstanceRoleInlinePolicy
+      PolicyDocument:
+        # https://docs.aws.amazon.com/eks/latest/userguide/security-iam-id-based-policy-examples.html#policy-example2
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - eks:DescribeCluster
+              - eks:ListClusters
+            Resource: "*"
+      Roles:
+        - !Ref K8sInstanceRole
+  K8sInstanceAccessEntry:
+    Type: AWS::EKS::AccessEntry
+    Properties:
+      ClusterName:
+        Fn::ImportValue: !Sub "${EksStackName}-K8sClusterName"
+      PrincipalArn: !GetAtt K8sInstanceRole.Arn
+      Type: STANDARD
+      AccessPolicies:
+        - AccessScope:
+            Type: cluster
+          PolicyArn: arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy
+          # https://docs.aws.amazon.com/eks/latest/userguide/access-policy-permissions.html#access-policy-permissions-amazoneksclusteradminpolicy
+      Tags:
+        - Key: Name
+          Value: opentelemetry-eks-ec2-access-entry


### PR DESCRIPTION
This pull request contains CloudFormation templates for Phase 1 and Phase 2.

For Phase 1, run the templates in the following order:

1. `opentelemetry-vpc.yaml`
2. `opentelemetry-docker.yaml`
3. `opentelemetry-eks.yaml`
4. `opentelemetry-kubernetes.yaml`

For Phase 2, re-use the templates from Phase 1 but use the `opentelemetry-kubernetes.yaml` file in the `phase-2` folder instead. This specific file does not apply any changes to EKS and assumes you will be running commands manually.

1. `opentelemetry-vpc.yaml`
2. `opentelemetry-eks.yaml`
3. `opentelemetry-kubernetes.yaml`